### PR TITLE
chore(misc): raise CMake minimum version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2.2)
+cmake_minimum_required(VERSION 3.16)
 project(revyv)
 
 include_directories("${PROJECT_SOURCE_DIR}/librevyv/include")


### PR DESCRIPTION
## Summary
- update the top-level CMake configuration to require CMake 3.16 so newer CMake versions do not fail

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d976b58b88832ba7be55a2bbee5fc6