### PR TITLE
fix(webbrowser): use minimal CEF bundle

### DIFF
--- a/webbrowser/README.md
+++ b/webbrowser/README.md
@@ -1,8 +1,8 @@
 # Webbrowser
 
 The `webbrowser` target integrates the Chromium Embedded Framework (CEF) into
-Revyv. The build automatically downloads the matching CEF binary distribution
-and links it against the project.
+Revyv. The build automatically downloads the matching minimal CEF binary
+distribution and links it against the project.
 
 ## CEF version
 
@@ -33,8 +33,8 @@ cmake -S webbrowser -B out/webbrowser
 cmake --build out/webbrowser
 ```
 
-The configure step downloads approximately 250 MB of prebuilt CEF binaries, so
-the initial run can take a few minutes depending on network speed.
+The configure step downloads the minimal prebuilt CEF binaries (roughly
+120 MB), so the initial run can take a few minutes depending on network speed.
 
 `cmake --build` will also compile the `librevyv` shared library and its
 `client-test` executable when the `webbrowser` project is configured on its own.

--- a/webbrowser/cmake/DownloadCEF.cmake
+++ b/webbrowser/cmake/DownloadCEF.cmake
@@ -10,7 +10,7 @@
 
 function(DownloadCEF platform version download_dir)
   # Specify the binary distribution type and download directory.
-  set(CEF_DISTRIBUTION "cef_binary_${version}_${platform}")
+  set(CEF_DISTRIBUTION "cef_binary_${version}_${platform}_minimal")
   set(CEF_DOWNLOAD_DIR "${download_dir}")
 
   # The location where we expect the extracted binary distribution.


### PR DESCRIPTION
## Summary
- switch the webbrowser project to download the minimal Chromium Embedded Framework bundle
- update documentation to reflect the reduced bundle size and minimal distribution usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9779cc1c0832bb0a368e2a7492fa9