### PR TITLE
Load CEF framework on macOS

### DIFF
--- a/webbrowser/src/main.cpp
+++ b/webbrowser/src/main.cpp
@@ -2,6 +2,7 @@
 #include "event_thread.h"
 #include "include/cef_app.h"
 #include "include/cef_render_handler.h"
+#include "include/wrapper/cef_library_loader.h"
 #include "render_handler.h"
 #include <argh.h>
 #include <iostream>
@@ -13,6 +14,12 @@ void* revyv = nullptr;
 int main(int argc, char* argv[])
 {
     CefMainArgs args(argc, argv);
+#if defined(__APPLE__)
+    CefScopedLibraryLoader library_loader;
+    if (!library_loader.LoadInMain()) {
+        return -1;
+    }
+#endif
     argh::parser cmdl({ "-f", "--frame", "-u", "--url" });
 
     cmdl.parse(argc, argv);


### PR DESCRIPTION
## Summary
- ensure the CEF framework is loaded on macOS before executing the renderer process

## Testing
- not run (macOS-specific change)


------
https://chatgpt.com/codex/tasks/task_e_68d97bb8d038832b879217f20e5bc84b